### PR TITLE
chore: stop fetching filing_elements for now

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -26,5 +26,5 @@ redaction_fields:
   - transaction.tranAdr2
   - transaction.tranZip4
   #filing_activities: []
-  filing_elements: []
+  # filing_elements: []
   elections: []


### PR DESCRIPTION
filing_elements contains many different kinds of records, some of which can contain addresses. We need to figure out what all fields need to be redacted before we start saving this data to Google Drive.